### PR TITLE
refactor(release): Broaden tag trigger to 'v*'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Build and Release Executables
 on:
   push:
     tags:
-      - 'v*.*'   # Trigger on version tags like v1.0 or v1.0.0
+      - 'v*'   # Trigger on version tags like v1.0, v1.0.0, v0.4-beta
   workflow_dispatch: # Allows manual triggering
     inputs:
       tag_name:


### PR DESCRIPTION
- Changed the `on: push: tags:` trigger in `release.yml` from `v*.*` to `v*` to support a wider range of tag formats, such as `v1.0-beta` or `v0.1alpha`.
- Reviewed and confirmed robustness of the `create-release` job in handling failed build dependencies and creating partial pre-releases.