### PR TITLE
fix(release): Prevent command substitution in release body script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,12 +107,14 @@ jobs:
         run: |
           body="Release of version ${{ needs.determine_tag.outputs.tag }}\n\n"
           if [[ "${{ needs.build-windows.result }}" == "success" ]]; then
-            body="${body}- Windows executable: `${{ needs.build-windows.outputs.executable_name }}` (Succeeded)\n"
+            WIN_EXEC_NAME="${{ needs.build-windows.outputs.executable_name }}"
+            body="${body}- Windows executable: \`${WIN_EXEC_NAME}\` (Succeeded)\n"
           else
             body="${body}- Windows build: Failed\n"
           fi
           if [[ "${{ needs.build-linux.result }}" == "success" ]]; then
-            body="${body}- Linux executable: `${{ needs.build-linux.outputs.executable_name }}` (Succeeded)\n"
+            LINUX_EXEC_NAME="${{ needs.build-linux.outputs.executable_name }}"
+            body="${body}- Linux executable: \`${LINUX_EXEC_NAME}\` (Succeeded)\n"
           else
             body="${body}- Linux build: Failed\n"
           fi


### PR DESCRIPTION
- Modified the 'Prepare Release Body' step in `release.yml`.
- Ensured that backticks around executable names are treated as literal characters for Markdown formatting by escaping them (e.g., \`name\`).
- This resolves an issue where the shell was attempting to execute the executable name as a command, leading to a 'command not found' error.