### PR TITLE
fix(release): Add checkout step to create-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,11 @@ jobs:
     permissions:
       contents: write # Required to create releases and upload assets
     steps:
+      - name: Checkout repository at specified tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.determine_tag.outputs.tag }} # Checkout the specific tag
+
       - name: Prepare Release Body
         id: prepare_body
         run: |


### PR DESCRIPTION
- Added an `actions/checkout@v4` step at the beginning of the `create-release` job.
- This provides the necessary Git repository context, which should prevent the `gh release delete` command from failing with a `fatal: not a git repository` error.
- This, in turn, should allow the release deletion to work correctly and resolve the subsequent `already_exists` error during release creation.