### PR TITLE
Add GitHub workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,18 @@ jobs:
           # sudo apt-get install -y upx # Example if UPX was used, build_exe.py specifies --noupx
 
       - name: Build executable with PyInstaller
-        run: python build_exe.py
+        run: python -u build_exe.py
+
+      - name: List contents of dist directory (Linux)
+        if: always() # Run this step even if the build failed to see partial output
+        run: |
+          echo "Listing contents of ./dist/ (if it exists):"
+          ls -lahR dist/ || echo "./dist/ directory not found or build failed to create it."
+          echo "Listing contents of current directory:"
+          ls -lah
+          echo "Checking for log files if PyInstaller created any (e.g., build/LapinCarotte/warn-LapinCarotte.txt):"
+          find build -name "*.txt" -print -exec cat {} \; || echo "No PyInstaller log files found in build/."
+
 
       - name: Upload Linux executable artifact
         uses: actions/upload-artifact@v4
@@ -128,7 +139,6 @@ jobs:
             # Potentially mark as prerelease or draft if both fail
           fi
           echo "RELEASE_BODY<<EOF" >> $GITHUB_OUTPUT
-          echo "$body" >> $GITHUB_OUTPUT
           echo "$body" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
@google-labs-jules
[fix(release): Correct release body script and enhance Linux build deb…](https://github.com/sheepdestroyer/LapinCarotte/pull/20/commits/4b9a53a9f22374ff5dae71ddc27e5dfccda8a84b) 
[4b9a53a](https://github.com/sheepdestroyer/LapinCarotte/pull/20/commits/4b9a53a9f22374ff5dae71ddc27e5dfccda8a84b)
…ugging

- Removed duplicated line in the 'Prepare Release Body' script.
- Enhanced the `build-linux` job for better debugging:
  - PyInstaller now runs with unbuffered Python output (`python -u`).
  - Added a new step (runs `if: always()`) after the build attempt to:
    - List contents of the `dist/` directory.
    - List contents of the current working directory.
    - Find and display any PyInstaller log/warning .txt files from the `build/` directory.
@google-labs-jules
[fix(release): Correct release body script and enhance Linux build deb…](https://github.com/sheepdestroyer/LapinCarotte/pull/20/commits/0eb980c954728e0120fabc8db60714470e315cf3) 
[0eb980c](https://github.com/sheepdestroyer/LapinCarotte/pull/20/commits/0eb980c954728e0120fabc8db60714470e315cf3)
…ugging

- Ensured 'Prepare Release Body' script does not duplicate content (verified file state).
- Enhanced the `build-linux` job for better debugging:
  - PyInstaller now runs with unbuffered Python output (`python -u`).
  - Added a new step (runs `if: always()`) after the build attempt to:
    - List contents of the `dist/` directory.
    - List contents of the current working directory.
    - Find and display any PyInstaller log/warning .txt files from the `build/` directory.
- Discussed auto-generated changelog options for releases.