### PR TITLE
feat: Upgrade workflows to Python 3.13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
           cache: 'pip'
 
       - name: Install dependencies
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
           cache: 'pip'
 
       - name: Install dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11' # Using Python 3.11, can be adjusted
+        python-version: '3.13'
         cache: 'pip' # Cache pip dependencies
 
     - name: Install dependencies


### PR DESCRIPTION
- Updated `python-version` to '3.13' in `actions/setup-python` steps within the following workflow files:
  - .github/workflows/run-tests.yml
  - .github/workflows/release.yml (for both build-windows and build-linux jobs)

- This change standardizes the Python version used across CI for tests and release builds to 3.13.