### PR TITLE
Refactor the main_entry_point function in main.py to improve readabil…

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,20 +35,9 @@ asset_manager = None
 game_state = None
 start_screen_image = None
 start_screen_pos = (0,0)
-restart_button_rect = pygame.Rect(0,0,0,0)
-exit_button_rect = pygame.Rect(0,0,0,0)
-start_button_rect = pygame.Rect(0,0,0,0)
-continue_button_rect = pygame.Rect(0,0,0,0)
-settings_button_rect = pygame.Rect(0,0,0,0)
-grass_image = None
 garlic_image = None
 hp_image_ui = None
 game_over_image_ui = None
-start_button_img = None
-exit_button_img = None
-restart_button_img = None
-continue_button_img = None
-settings_button_img = None
 grass_background = None
 start_screen_buttons = []
 game_over_buttons = []
@@ -163,6 +152,194 @@ def open_settings_callback():
     """
     logging.debug("open_settings_callback called. / open_settings_callback appelé.")
     logging.info("Settings button clicked - Feature not implemented yet. / Bouton Paramètres cliqué - Fonctionnalité non encore implémentée.")
+
+def parse_arguments():
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="LapinCarotte - A game about a rabbit fighting vampire carrots. / *Un jeu sur un lapin combattant des carottes vampires.*")
+    parser.add_argument("--cli", action="store_true", help="Run the game in Command Line Interface mode (no graphics). / *Exécuter le jeu en mode Interface en Ligne de Commande (sans graphismes).*")
+    parser.add_argument("-d", "--debug", action="store_true", help="Enable debug logging output. / *Activer la sortie de journalisation de débogage.*")
+    return parser.parse_args()
+
+def setup_logging(args):
+    """Configure logging based on command-line arguments."""
+    log_level = logging.DEBUG if args.debug else logging.INFO
+    logger = logging.getLogger()
+    logger.setLevel(log_level)
+    if logger.hasHandlers():
+        logger.handlers.clear()
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setLevel(log_level)
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - [%(filename)s:%(lineno)d] - %(message)s")
+    stdout_handler.setFormatter(formatter)
+    logger.addHandler(stdout_handler)
+    logging.info("Application starting... / Démarrage de l'application...")
+    if args.cli:
+        logging.info("CLI mode enabled. / Mode CLI activé.")
+    if args.debug:
+        logging.info("Debug logging enabled. / Journalisation de débogage activée.")
+
+def initialize_pygame(args):
+    """Initialize Pygame and the display screen."""
+    if args.cli:
+        return None, 0, 0
+    pygame.init()
+    os.environ['SDL_VIDEO_CENTERED'] = '1'
+    screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN | pygame.HWSURFACE | pygame.DOUBLEBUF)
+    screen_width, screen_height = screen.get_size()
+    pygame.mouse.set_visible(False)
+    return screen, screen_width, screen_height
+
+def load_game_assets(args, asset_manager, screen_width, screen_height):
+    """Load all game assets."""
+    asset_manager.load_assets()
+    assets = {
+        'start_button_img': asset_manager.images.get('start'),
+        'exit_button_img': asset_manager.images.get('exit'),
+        'restart_button_img': asset_manager.images.get('restart'),
+        'continue_button_img': asset_manager.images.get('continue_button'),
+        'settings_button_img': asset_manager.images.get('settings_button'),
+        'start_screen_image': None,
+        'grass_background': None,
+        'garlic_image': asset_manager.images.get('garlic'),
+        'hp_image_ui': asset_manager.images.get('hp'),
+        'game_over_image_ui': asset_manager.images.get('game_over'),
+        'start_screen_pos': (0, 0)
+    }
+
+    if not args.cli:
+        if 'icon' in asset_manager.images and hasattr(asset_manager.images['icon'], 'get_rect'):
+            pygame.display.set_icon(asset_manager.images['icon'])
+
+        if sys.platform == 'win32':
+            import ctypes
+            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID('LapinCarotte.LapinCarotte.Game.1.0')
+            pygame.display.set_caption("LapinCarotte", "LapinCarotte")
+
+        start_screen_image = asset_manager.images.get('start_screen')
+        if start_screen_image and hasattr(start_screen_image, 'get_width') and hasattr(start_screen_image, 'get_height'):
+            assets['start_screen_image'] = start_screen_image
+            assets['start_screen_pos'] = (
+                (screen_width - start_screen_image.get_width()) // 2,
+                (screen_height - start_screen_image.get_height()) // 2
+            )
+
+        grass_image = asset_manager.images.get('grass')
+        if grass_image and hasattr(grass_image, 'get_size'):
+            grass_background = pygame.Surface(WORLD_SIZE, pygame.SRCALPHA)
+            _grass_w, _grass_h = grass_image.get_size()
+            if _grass_w > 0 and _grass_h > 0:
+                for x_g in range(0, WORLD_SIZE[0], _grass_w):
+                    for y_g in range(0, WORLD_SIZE[1], _grass_h):
+                        grass_background.blit(grass_image, (x_g, y_g))
+            else:
+                logging.warning("Grass asset has invalid dimensions, cannot tile background.")
+                grass_background.fill((0,100,0))
+            assets['grass_background'] = grass_background
+
+        if pygame.mixer.get_init():
+            try:
+                intro_music_path = get_asset_path(config.MUSIC_INTRO)
+                pygame.mixer.music.load(intro_music_path)
+                pygame.mixer.music.play(-1)
+            except pygame.error as e:
+                logging.warning(f"Could not load or play intro music: {e}")
+        else:
+            logging.warning("Pygame mixer not initialized, skipping music.")
+
+    return assets
+
+def create_buttons(args, screen_width, screen_height, assets, callbacks):
+    """Create all UI buttons for the game."""
+    start_screen_pos = assets['start_screen_pos']
+    start_button_img = assets['start_button_img']
+    exit_button_img = assets['exit_button_img']
+    restart_button_img = assets['restart_button_img']
+    continue_button_img = assets['continue_button_img']
+    settings_button_img = assets['settings_button_img']
+
+    # Button Rects - these are needed for positioning calculations
+    restart_button_rect = pygame.Rect(0,0,0,0)
+    exit_button_rect = pygame.Rect(0,0,0,0)
+    start_button_rect = pygame.Rect(0,0,0,0)
+    continue_button_rect = pygame.Rect(0,0,0,0)
+    settings_button_rect = pygame.Rect(0,0,0,0)
+
+    if not args.cli:
+        # Use assets dictionary to get images
+        _restart_img_temp = assets.get('restart_button_img')
+        if _restart_img_temp and hasattr(_restart_img_temp, 'get_rect'): restart_button_rect = _restart_img_temp.get_rect()
+
+        _exit_img_temp = assets.get('exit_button_img')
+        if _exit_img_temp and hasattr(_exit_img_temp, 'get_rect'): exit_button_rect = _exit_img_temp.get_rect()
+
+        _start_img_temp = assets.get('start_button_img')
+        if _start_img_temp and hasattr(_start_img_temp, 'get_rect'): start_button_rect = _start_img_temp.get_rect()
+
+        _continue_img_temp = assets.get('continue_button_img')
+        if _continue_img_temp and hasattr(_continue_img_temp, 'get_rect'): continue_button_rect = _continue_img_temp.get_rect()
+
+        _settings_img_temp = assets.get('settings_button_img')
+        if _settings_img_temp and hasattr(_settings_img_temp, 'get_rect'): settings_button_rect = _settings_img_temp.get_rect()
+
+    start_button_start_screen = Button(
+        start_screen_pos[0] + START_SCREEN_BUTTON_START_X_OFFSET,
+        start_screen_pos[1] + START_SCREEN_BUTTON_START_Y_OFFSET,
+        start_button_img,
+        callbacks['start'],
+        cli_mode=args.cli
+    )
+    exit_button_start_screen = Button(
+        start_screen_pos[0] + START_SCREEN_BUTTON_EXIT_X_OFFSET,
+        start_screen_pos[1] + START_SCREEN_BUTTON_EXIT_Y_OFFSET,
+        exit_button_img,
+        callbacks['quit'],
+        cli_mode=args.cli
+    )
+    start_screen_buttons = [start_button_start_screen, exit_button_start_screen]
+
+    _restart_w = restart_button_rect.width if not args.cli and restart_button_img and hasattr(restart_button_img, 'get_width') else (DEFAULT_PLACEHOLDER_SIZE[0] if args.cli else 0)
+    _exit_w = exit_button_rect.width if not args.cli and exit_button_img and hasattr(exit_button_img, 'get_width') else (DEFAULT_PLACEHOLDER_SIZE[0] if args.cli else 0)
+
+    restart_button_game_over_screen = Button(
+        screen_width / 2 - _restart_w - BUTTON_SPACING / 2 if screen_width > 0 else 0,
+        screen_height * 3 / 4 - restart_button_rect.height / 2 if screen_height > 0 else 0,
+        restart_button_img,
+        callbacks['reset'],
+        cli_mode=args.cli
+    )
+    exit_button_game_over_screen = Button(
+        screen_width / 2 + BUTTON_SPACING / 2 if screen_width > 0 else 0,
+        screen_height * 3 / 4 - exit_button_rect.height / 2 if screen_height > 0 else 0,
+        exit_button_img,
+        callbacks['quit'],
+        cli_mode=args.cli
+    )
+    game_over_buttons = [restart_button_game_over_screen, exit_button_game_over_screen]
+
+    _continue_w = continue_button_rect.width if not args.cli and continue_button_img and hasattr(continue_button_img, 'get_width') else (DEFAULT_PLACEHOLDER_SIZE[0] if args.cli else 0)
+    _settings_w = settings_button_rect.width if not args.cli and settings_button_img and hasattr(settings_button_img, 'get_width') else (DEFAULT_PLACEHOLDER_SIZE[0] if args.cli else 0)
+
+    continue_button_pause_screen = Button(
+        screen_width / 2 - _continue_w / 2 if screen_width > 0 else 0,
+        screen_height * 0.5 - continue_button_rect.height - BUTTON_SPACING / 2 if screen_height > 0 else 0,
+        continue_button_img,
+        callbacks['resume'],
+        cli_mode=args.cli
+    )
+    settings_button_pause_screen = Button(
+        screen_width / 2 - _settings_w / 2 if screen_width > 0 else 0,
+        screen_height * 0.5 + BUTTON_SPACING / 2 if screen_height > 0 else 0,
+        settings_button_img,
+        callbacks['settings'],
+        cli_mode=args.cli
+    )
+    pause_screen_buttons = [continue_button_pause_screen, settings_button_pause_screen]
+
+    return {
+        'start': start_screen_buttons,
+        'game_over': game_over_buttons,
+        'pause': pause_screen_buttons
+    }
 
 def run_gui_mode():
     """
@@ -512,172 +689,40 @@ def main_loop():
 def main_entry_point():
     global args, screen, screen_width, screen_height, asset_manager, game_state, current_time
     global start_screen_image, start_screen_pos
-    global restart_button_rect, exit_button_rect, start_button_rect, continue_button_rect, settings_button_rect
-    global grass_image, garlic_image, hp_image_ui, game_over_image_ui
-    global start_button_img, exit_button_img, restart_button_img, continue_button_img, settings_button_img
-    global grass_background
+    global grass_background, garlic_image, hp_image_ui, game_over_image_ui
     global start_screen_buttons, game_over_buttons, pause_screen_buttons
-    global running, can_toggle_pause # Make sure these are global if they are set before main_loop
+    global running, can_toggle_pause
 
-    parser = argparse.ArgumentParser(description="LapinCarotte - A game about a rabbit fighting vampire carrots. / *Un jeu sur un lapin combattant des carottes vampires.*")
-    parser.add_argument("--cli", action="store_true", help="Run the game in Command Line Interface mode (no graphics). / *Exécuter le jeu en mode Interface en Ligne de Commande (sans graphismes).*")
-    parser.add_argument("-d", "--debug", action="store_true", help="Enable debug logging output. / *Activer la sortie de journalisation de débogage.*")
-    args = parser.parse_args()
+    args = parse_arguments()
+    setup_logging(args)
 
-    # Configure logging based on --debug argument
-    log_level = logging.DEBUG if args.debug else logging.INFO
-    logger = logging.getLogger()
-    logger.setLevel(log_level)
-    if logger.hasHandlers():
-        logger.handlers.clear()
-    stdout_handler = logging.StreamHandler(sys.stdout)
-    stdout_handler.setLevel(log_level)
-    formatter = logging.Formatter("%(asctime)s - %(levelname)s - [%(filename)s:%(lineno)d] - %(message)s")
-    stdout_handler.setFormatter(formatter)
-    logger.addHandler(stdout_handler)
-
-    logging.info("Application starting... / Démarrage de l'application...")
-    if args.cli:
-        logging.info("CLI mode enabled. / Mode CLI activé.")
-    if args.debug:
-        logging.info("Debug logging enabled. / Journalisation de débogage activée.")
-
-    if not args.cli:
-        pygame.init()
-        os.environ['SDL_VIDEO_CENTERED'] = '1'
-        screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN | pygame.HWSURFACE | pygame.DOUBLEBUF)
-        screen_width, screen_height = screen.get_size()
-        pygame.mouse.set_visible(False)
+    screen, screen_width, screen_height = initialize_pygame(args)
 
     asset_manager = AssetManager(cli_mode=args.cli)
-    asset_manager.load_assets()
+    assets = load_game_assets(args, asset_manager, screen_width, screen_height)
 
-    if not args.cli and screen and 'icon' in asset_manager.images and hasattr(asset_manager.images['icon'], 'get_rect'):
-        pygame.display.set_icon(asset_manager.images['icon'])
-
-    if sys.platform == 'win32' and not args.cli:
-        import ctypes
-        ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID('LapinCarotte.LapinCarotte.Game.1.0')
-        pygame.display.set_caption("LapinCarotte", "LapinCarotte")
+    # Set global variables for run_gui_mode to use
+    start_screen_image = assets['start_screen_image']
+    start_screen_pos = assets['start_screen_pos']
+    grass_background = assets['grass_background']
+    garlic_image = assets['garlic_image']
+    hp_image_ui = assets['hp_image_ui']
+    game_over_image_ui = assets['game_over_image_ui']
 
     game_state = GameState(asset_manager, cli_mode=args.cli)
 
-    # Re-initialize UI elements that depend on screen_width, screen_height, or loaded assets
-    start_button_img = asset_manager.images.get('start')
-    exit_button_img = asset_manager.images.get('exit')
-    restart_button_img = asset_manager.images.get('restart')
-    continue_button_img = asset_manager.images.get('continue_button')
-    settings_button_img = asset_manager.images.get('settings_button')
+    callbacks = {
+        'start': start_game,
+        'quit': quit_game,
+        'reset': reset_game,
+        'resume': resume_game_callback,
+        'settings': open_settings_callback
+    }
 
-    if not args.cli:
-        start_screen_image = asset_manager.images.get('start_screen')
-        if start_screen_image and hasattr(start_screen_image, 'get_width') and hasattr(start_screen_image, 'get_height'):
-            start_screen_pos = (
-                (screen_width - start_screen_image.get_width()) // 2,
-                (screen_height - start_screen_image.get_height()) // 2
-            )
-
-        _restart_img_temp = asset_manager.images.get('restart')
-        if _restart_img_temp and hasattr(_restart_img_temp, 'get_rect'): restart_button_rect = _restart_img_temp.get_rect()
-
-        _exit_img_temp = asset_manager.images.get('exit')
-        if _exit_img_temp and hasattr(_exit_img_temp, 'get_rect'): exit_button_rect = _exit_img_temp.get_rect()
-
-        _start_img_temp = asset_manager.images.get('start')
-        if _start_img_temp and hasattr(_start_img_temp, 'get_rect'): start_button_rect = _start_img_temp.get_rect()
-
-        _continue_img_temp = asset_manager.images.get('continue_button')
-        if _continue_img_temp and hasattr(_continue_img_temp, 'get_rect'): continue_button_rect = _continue_img_temp.get_rect()
-
-        _settings_img_temp = asset_manager.images.get('settings_button')
-        if _settings_img_temp and hasattr(_settings_img_temp, 'get_rect'): settings_button_rect = _settings_img_temp.get_rect()
-
-        grass_image = asset_manager.images.get('grass')
-        if grass_image and hasattr(grass_image, 'get_size'):
-            grass_background = pygame.Surface(WORLD_SIZE, pygame.SRCALPHA)
-            _grass_w, _grass_h = grass_image.get_size()
-            if _grass_w > 0 and _grass_h > 0:
-                for x_g in range(0, WORLD_SIZE[0], _grass_w):
-                    for y_g in range(0, WORLD_SIZE[1], _grass_h):
-                        grass_background.blit(grass_image, (x_g, y_g))
-            else:
-                logging.warning("Grass asset has invalid dimensions, cannot tile background.")
-                grass_background.fill((0,100,0))
-
-        garlic_image = asset_manager.images.get('garlic')
-        hp_image_ui = asset_manager.images.get('hp')
-        game_over_image_ui = asset_manager.images.get('game_over')
-
-        if pygame.mixer.get_init():
-            try:
-                intro_music_path = get_asset_path(config.MUSIC_INTRO)
-                pygame.mixer.music.load(intro_music_path)
-                pygame.mixer.music.play(-1)
-            except pygame.error as e:
-                logging.warning(f"Could not load or play intro music: {e}")
-        else:
-            logging.warning("Pygame mixer not initialized, skipping music.")
-
-    # Button instances (need to be re-created or updated if their positions depend on screen_width/height)
-    # Ensure start_screen_pos is defined even for CLI for Button instantiation if they use it.
-    if args.cli and start_screen_pos == (0,0) and start_screen_image is None:
-        pass
-
-
-    start_button_start_screen = Button(
-        start_screen_pos[0] + START_SCREEN_BUTTON_START_X_OFFSET,
-        start_screen_pos[1] + START_SCREEN_BUTTON_START_Y_OFFSET,
-        start_button_img,
-        start_game,
-        cli_mode=args.cli
-    )
-    exit_button_start_screen = Button(
-        start_screen_pos[0] + START_SCREEN_BUTTON_EXIT_X_OFFSET,
-        start_screen_pos[1] + START_SCREEN_BUTTON_EXIT_Y_OFFSET,
-        exit_button_img,
-        quit_game,
-        cli_mode=args.cli
-    )
-    start_screen_buttons = [start_button_start_screen, exit_button_start_screen]
-
-    _restart_w = restart_button_rect.width if not args.cli and restart_button_img and hasattr(restart_button_img, 'get_width') else (DEFAULT_PLACEHOLDER_SIZE[0] if args.cli else 0)
-    _exit_w = exit_button_rect.width if not args.cli and exit_button_img and hasattr(exit_button_img, 'get_width') else (DEFAULT_PLACEHOLDER_SIZE[0] if args.cli else 0)
-
-    restart_button_game_over_screen = Button(
-        screen_width / 2 - _restart_w - BUTTON_SPACING / 2 if screen_width > 0 else 0,
-        screen_height * 3 / 4 - restart_button_rect.height / 2 if screen_height > 0 else 0,
-        restart_button_img,
-        reset_game,
-        cli_mode=args.cli
-    )
-    exit_button_game_over_screen = Button(
-        screen_width / 2 + BUTTON_SPACING / 2 if screen_width > 0 else 0,
-        screen_height * 3 / 4 - exit_button_rect.height / 2 if screen_height > 0 else 0,
-        exit_button_img,
-        quit_game,
-        cli_mode=args.cli
-    )
-    game_over_buttons = [restart_button_game_over_screen, exit_button_game_over_screen]
-
-    _continue_w = continue_button_rect.width if not args.cli and continue_button_img and hasattr(continue_button_img, 'get_width') else (DEFAULT_PLACEHOLDER_SIZE[0] if args.cli else 0)
-    _settings_w = settings_button_rect.width if not args.cli and settings_button_img and hasattr(settings_button_img, 'get_width') else (DEFAULT_PLACEHOLDER_SIZE[0] if args.cli else 0)
-
-    continue_button_pause_screen = Button(
-        screen_width / 2 - _continue_w / 2 if screen_width > 0 else 0,
-        screen_height * 0.5 - continue_button_rect.height - BUTTON_SPACING / 2 if screen_height > 0 else 0,
-        continue_button_img,
-        resume_game_callback,
-        cli_mode=args.cli
-    )
-    settings_button_pause_screen = Button(
-        screen_width / 2 - _settings_w / 2 if screen_width > 0 else 0,
-        screen_height * 0.5 + BUTTON_SPACING / 2 if screen_height > 0 else 0,
-        settings_button_img,
-        open_settings_callback,
-        cli_mode=args.cli
-    )
-    pause_screen_buttons = [continue_button_pause_screen, settings_button_pause_screen]
-
+    buttons = create_buttons(args, screen_width, screen_height, assets, callbacks)
+    start_screen_buttons = buttons['start']
+    game_over_buttons = buttons['game_over']
+    pause_screen_buttons = buttons['pause']
 
     current_time = time.time()
     running = True

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -255,26 +255,10 @@ def mock_pygame_modules(monkeypatch):
     # These are now moved to main_entry_point, so this direct patching might be less critical
     # if tests are structured to call main_entry_point or if Button creation is also mocked/deferred.
     # However, to be safe for any test importing main and expecting these to be somewhat valid:
-    monkeypatch.setattr('main.start_button_img', mock_asset_manager_instance.images.get('start'))
-    monkeypatch.setattr('main.exit_button_img', mock_asset_manager_instance.images.get('exit'))
-    monkeypatch.setattr('main.restart_button_img', mock_asset_manager_instance.images.get('restart'))
-    monkeypatch.setattr('main.continue_button_img', mock_asset_manager_instance.images.get('continue_button'))
-    monkeypatch.setattr('main.settings_button_img', mock_asset_manager_instance.images.get('settings_button'))
-
-    # Initialize global rects in main, as Button() calls might use their .width/.height
-    # These are initialized to Rect(0,0,0,0) in main.py. For tests, if Button() constructor
-    # relies on these having dimensions from loaded images, we should provide mocks.
-    # The mock_asset_manager_instance.images already provide mock surfaces with get_rect().
-    # The current Button constructor in main.py uses these image objects directly.
-    # The _*_width variables in main_entry_point handle cases where images are not surfaces (CLI).
-    # So this part should be fine as long as the image mocks in asset_manager have get_rect.
-    # The global rects (e.g., main.restart_button_rect) are used if not args.cli for some calculations.
-    # Let's ensure they are at least valid pygame.Rect objects.
-    monkeypatch.setattr('main.restart_button_rect', mock_asset_manager_instance.images['restart'].get_rect())
-    monkeypatch.setattr('main.exit_button_rect', mock_asset_manager_instance.images['exit'].get_rect())
-    monkeypatch.setattr('main.start_button_rect', mock_asset_manager_instance.images['start'].get_rect())
-    monkeypatch.setattr('main.continue_button_rect', mock_asset_manager_instance.images['continue_button'].get_rect())
-    monkeypatch.setattr('main.settings_button_rect', mock_asset_manager_instance.images['settings_button'].get_rect())
+    # The global variables for button images and rects have been removed from main.py
+    # and are now created within functions. The tests for callbacks don't depend on them,
+    # so we can remove the monkeypatching for them.
+    pass
 
 
 # NOTE: L'import de `main` est fait dans chaque fonction de test ci-dessous.


### PR DESCRIPTION
Refactor the main_entry_point function in main.py to improve readability and maintainability.

The monolithic main_entry_point function was broken down into smaller, more focused helper functions, each responsible for a specific part of the game's setup process:
- `parse_arguments`: Parses command-line arguments.
- `setup_logging`: Configures logging.
- `initialize_pygame`: Initializes Pygame and the screen.
- `load_game_assets`: Loads all game assets.
- `create_buttons`: Creates all UI buttons.

This change addresses the code review comment suggesting this refactoring.

The tests in `tests/test_main_flow.py` were also updated to accommodate the removal of global variables that were previously used for storing assets and UI elements.