### PR TITLE
Fix/vampire draw bug and imports

### DIFF
--- a/game_entities.py
+++ b/game_entities.py
@@ -10,16 +10,25 @@
 # *et les éléments d'interface utilisateur comme les Boutons. Chaque classe gère généralement
 # *son propre état, son comportement (logique de mise à jour) et son affichage.*
 
-import pygame
 import math
 import random
 import time
-from config import *
-from config import (UI_HEALTH_X_OFFSET, UI_HEALTH_Y_OFFSET, UI_HEALTH_SPACING,
-                    UI_GARLIC_X_OFFSET, UI_GARLIC_Y_OFFSET, UI_GARLIC_SPACING,
-                    UI_JUICE_COUNTER_DIGIT_SPACING, UI_JUICE_COUNTER_DIGIT_SCALE,
-                    VAMPIRE_DEATH_FLASH_INTERVAL, VAMPIRE_DEATH_TINT_COLOR)
-from utilities import *
+
+import pygame
+
+from config import (BULLET_SPEED, CARROT_CHASE_RADIUS, CARROT_DETECTION_RADIUS,
+                    CARROT_SPEED, EXPLOSION_FLASH_INTERVAL,
+                    EXPLOSION_MAX_FLASHES, GARLIC_ROTATION_SPEED,
+                    GARLIC_SHOT_MAX_TRAVEL, GARLIC_SHOT_SPEED, MAX_HEALTH,
+                    MAX_SPEED_MULTIPLIER, PLAYER_INVINCIBILITY_DURATION,
+                    PLAYER_SPEED, START_HEALTH, UI_GARLIC_SPACING,
+                    UI_GARLIC_X_OFFSET, UI_GARLIC_Y_OFFSET,
+                    UI_HEALTH_SPACING, UI_HEALTH_X_OFFSET,
+                    UI_HEALTH_Y_OFFSET, UI_JUICE_COUNTER_DIGIT_SCALE,
+                    UI_JUICE_COUNTER_DIGIT_SPACING, VAMPIRE_DEATH_DURATION,
+                    VAMPIRE_DEATH_FLASH_INTERVAL, VAMPIRE_DEATH_TINT_COLOR,
+                    VAMPIRE_RESPAWN_TIME, VAMPIRE_SPEED)
+from utilities import calculate_movement_towards, get_direction_vector
 
 class GameObject:
     """
@@ -680,19 +689,6 @@ class Vampire(GameObject):
                            # *Dessiner normalement si actif et pas en effet de mort*
             super().draw(screen, scroll)
 
-        if not self.cli_mode and hasattr(image, 'get_rect'):
-            self.rect = self.image.get_rect(topleft=(x,y))
-        else:
-            # In CLI mode, buttons might not need a rect, or a default one.
-            # Or, main.py should not instantiate Button objects with image metadata if not needed.
-            # For now, create a default rect to prevent crashes during instantiation.
-            # Button positioning logic in main.py might need to be CLI-aware too.
-            width, height = 0,0
-            if isinstance(image, dict): # Check if it's metadata from AssetManager CLI mode
-                size_info = image.get('size_hint') # Rely only on size_hint
-                if size_info:
-                    width, height = size_info
-            self.rect = pygame.Rect(x, y, width, height)
 
 class Button(GameObject): # Button is also a GameObject
     """

--- a/main.py
+++ b/main.py
@@ -11,19 +11,27 @@
 # *transitions entre les différents états du jeu (écran de démarrage, jeu actif, écran de pause, game over).*
 # *Il prend en charge les modes GUI et CLI.*
 
-import os
 import argparse
-import pygame
-import time
 import logging
-import sys
-import random
 import math
-import config # Should be imported before other modules that might depend on it if not for "from config import *"
+import os
+import random
+import sys
+import time
+
+import pygame
+
+import config
 from asset_manager import AssetManager, DummySound
-from game_entities import Player, Bullet, Carrot, Vampire, Explosion, Collectible, Button
+from config import (BUTTON_SPACING, DEFAULT_PLACEHOLDER_SIZE, MAX_GARLIC,
+                    PLAYER_INVINCIBILITY_FLASH_FREQUENCY,
+                    START_SCREEN_BUTTON_EXIT_X_OFFSET,
+                    START_SCREEN_BUTTON_EXIT_Y_OFFSET,
+                    START_SCREEN_BUTTON_START_X_OFFSET,
+                    START_SCREEN_BUTTON_START_Y_OFFSET, WORLD_SIZE)
+from game_entities import (Button, Bullet, Carrot, Collectible, Explosion,
+                           Player, Vampire)
 from game_state import GameState
-from config import * # Import all constants from config.py / *Importer toutes les constantes de config.py*
 from utilities import get_asset_path
 
 # Global variables initialized with default/None values

--- a/main.py
+++ b/main.py
@@ -29,8 +29,7 @@ from config import (BUTTON_SPACING, DEFAULT_PLACEHOLDER_SIZE, MAX_GARLIC,
                     START_SCREEN_BUTTON_EXIT_Y_OFFSET,
                     START_SCREEN_BUTTON_START_X_OFFSET,
                     START_SCREEN_BUTTON_START_Y_OFFSET, WORLD_SIZE)
-from game_entities import (Button, Bullet, Carrot, Collectible, Explosion,
-                           Player, Vampire)
+from game_entities import Button
 from game_state import GameState
 from utilities import get_asset_path
 

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -221,7 +221,7 @@ def mock_pygame_modules(monkeypatch):
     _mock_gs.paused = False
     _mock_gs.game_over = False
     _mock_gs.player = MagicMock()
-    _mock_gs.player.health = main.START_HEALTH # Access START_HEALTH from main's imported config
+    _mock_gs.player.health = config.START_HEALTH # Access START_HEALTH from main's imported config
     _mock_gs.asset_manager = mock_asset_manager_instance # Ensure the mock GameState uses the mock AssetManager
     _mock_gs.cli_mode = default_args.cli
 
@@ -231,7 +231,7 @@ def mock_pygame_modules(monkeypatch):
         _mock_gs.game_over = False
         _mock_gs.paused = False
         # Simulate other reset actions if necessary for other tests
-        _mock_gs.player.health = main.START_HEALTH # Use main.START_HEALTH for consistency
+        _mock_gs.player.health = config.START_HEALTH # Use main.START_HEALTH for consistency
         # Add other resets like bullets = [], items = [], etc. if tests depend on them after reset
         # For example:
         # _mock_gs.bullets = []
@@ -324,7 +324,7 @@ def test_reset_game_functionality(mock_pygame_modules):
 
     assert main.game_state.started == False
     assert main.game_state.game_over == False
-    assert main.game_state.player.health == main.START_HEALTH # Vérifier une valeur spécifique réinitialisée
+    assert main.game_state.player.health == config.START_HEALTH # Vérifier une valeur spécifique réinitialisée
     main.asset_manager.sounds['press_start'].play.assert_called_once()
 
     # NOTE: Debug assertion removed.


### PR DESCRIPTION
Fix critical bug in Vampire.draw method

A misplaced block of code in the `Vampire.draw` method was causing a
`NameError` due to using variables not defined in the method's scope.
This commit removes the erroneous code block to prevent the game from
crashing.

Refactor imports in main.py and game_entities.py

The import statements in `main.py` and `game_entities.py` have been
refactored to be more explicit and follow standard Python conventions.
Wildcard imports (`from ... import *`) have been replaced with
specific imports of the required classes and constants. This improves
code readability and maintainability.

Remove unused imports from main.py

Removed unused imports from `game_entities` in `main.py` to keep the
namespace clean.