### PR TITLE
Refactor game state imports

### DIFF
--- a/game_state.py
+++ b/game_state.py
@@ -39,6 +39,7 @@ class GameState:
         self.scroll = [0, 0]  # Camera scroll position / *Position de défilement de la caméra*
         self.scroll_trigger = config.SCROLL_TRIGGER  # Screen edge percentage to trigger scroll / *Pourcentage du bord de l'écran pour déclencher le défilement*
         self.world_size = config.WORLD_SIZE  # Total dimensions of the game world / *Dimensions totales du monde du jeu*
+        self.carrot_spawn_safe_radius_sq = (min(self.world_size) / config.CARROT_SPAWN_SAFE_RATIO)**2
         self.game_over = False  # True if the game has ended / *True si le jeu est terminé*
         self.started = False  # True if the game has started (past the initial screen) / *True si le jeu a commencé (après l'écran initial)*
         self.paused = False  # True if the game is currently paused / *True si le jeu est actuellement en pause*
@@ -208,7 +209,7 @@ class GameState:
 
             if not self.player or \
                ((x - player_center_x)**2 +
-                (y - player_center_y)**2 > (min(self.world_size)/config.CARROT_SPAWN_SAFE_RATIO)**2):
+                (y - player_center_y)**2 > self.carrot_spawn_safe_radius_sq):
                 self.carrots.append(Carrot(x, y, carrot_image_data, cli_mode=self.cli_mode))
                 break
 
@@ -286,12 +287,8 @@ class GameState:
             # Check for collision with vampire (only if garlic shot still exists and is active)
             # *Vérifier la collision avec le vampire (seulement si le tir d'ail existe encore et est actif)*
             if self.garlic_shot and self.garlic_shot["active"] and self.vampire.active:
-                # Ensure garlic_width and garlic_height are accessible or defined
-                # *S'assurer que garlic_width et garlic_height sont accessibles ou définis*
-                garlic_rect = pygame.Rect(self.garlic_shot["x"] - config.GARLIC_WIDTH / 2,
-                                          self.garlic_shot["y"] - config.GARLIC_HEIGHT / 2,
-                                          config.GARLIC_WIDTH, config.GARLIC_HEIGHT)
-                if garlic_rect.colliderect(self.vampire.rect):
+                self.garlic_shot["rect"].center = (self.garlic_shot["x"], self.garlic_shot["y"])
+                if self.garlic_shot["rect"].colliderect(self.vampire.rect):
                     self.vampire.death_effect_active = True
                     self.vampire.death_effect_start_time = current_time
                     self.vampire.active = False

--- a/main.py
+++ b/main.py
@@ -457,11 +457,14 @@ def run_gui_mode():
                     dx_norm, dy_norm = (dx/dist, dy/dist) if dist > 0 else (0,1)
                     angle = math.degrees(math.atan2(-dy_norm, dx_norm))
 
+                    rect = pygame.Rect(0, 0, config.GARLIC_WIDTH, config.GARLIC_HEIGHT)
+                    rect.center = (start_x, start_y)
                     game_state.garlic_shot = {
                         "x": start_x, "y": start_y,
                         "dx": dx_norm, "dy": dy_norm,
                         "angle": angle, "active": True,
-                        "rotation_angle": angle
+                        "rotation_angle": angle,
+                        "rect": rect
                     }
                     game_state.garlic_shot_travel = 0
                     logging.debug(f"Garlic shot initiated towards ({world_mouse_x},{world_mouse_y}) with angle {angle:.2f} / Tir d'ail initié vers ({world_mouse_x},{world_mouse_y}) avec un angle de {angle:.2f}")

--- a/tests/test_game_state.py
+++ b/tests/test_game_state.py
@@ -223,31 +223,23 @@ class TestGameStateUpdate:
         assert gs.bullets[0].rect.centerx == initial_center_x_on_screen + BULLET_SPEED
 
     @patch('time.time')
-    @patch('game_state.pygame.Rect')
-    def test_update_garlic_shot_vampire_collision(self, mock_pygame_rect_class, mock_time, game_state_instance, mock_asset_manager):
+    def test_update_garlic_shot_vampire_collision(self, mock_time, game_state_instance, mock_asset_manager):
         gs = game_state_instance; vampire = gs.vampire; current_time = 100.0
         mock_time.return_value = current_time
-        mock_pygame_rect_class.return_value.colliderect.return_value = True
 
         vampire.rect = pygame.Rect(200, 200, 40, 40); vampire.active = True
         gs.garlic_shot = {
             "active": True, "x": 200, "y": 200, "dx": 1, "dy": 0,
-            "image": MagicMock(), "rotation_angle": 0
+            "image": MagicMock(), "rotation_angle": 0, "rect": pygame.Rect(195, 195, 10, 10)
         }
+        gs.garlic_shot["rect"].center = (gs.garlic_shot["x"], gs.garlic_shot["y"])
         gs.garlic_shot_start_time = current_time - 0.1; gs.garlic_shot_travel = 0
         gs.garlic_shot_speed = GARLIC_SHOT_SPEED; gs.garlic_shot_duration = GARLIC_SHOT_DURATION
 
-        expected_center_x_after_move = gs.garlic_shot["x"] + gs.garlic_shot["dx"] * gs.garlic_shot_speed
-        expected_center_y_after_move = gs.garlic_shot["y"] + gs.garlic_shot["dy"] * gs.garlic_shot_speed
-
-        expected_topleft_x = expected_center_x_after_move - GARLIC_WIDTH / 2
-        expected_topleft_y = expected_center_y_after_move - GARLIC_HEIGHT / 2
-
         gs.update(current_time)
 
-        mock_pygame_rect_class.assert_called_with(pytest.approx(expected_topleft_x), pytest.approx(expected_topleft_y), GARLIC_WIDTH, GARLIC_HEIGHT)
-        mock_pygame_rect_class.return_value.colliderect.assert_called_once_with(vampire.rect)
         assert vampire.death_effect_active
+        assert gs.garlic_shot is None
 
     @patch('time.time')
     def test_update_player_vampire_collision(self, mock_time, game_state_instance):
@@ -363,7 +355,7 @@ class TestGameStateUpdate:
     @patch('time.time')
     def test_update_garlic_shot_expiration_by_travel(self, mock_time, game_state_instance, mock_asset_manager):
         gs = game_state_instance; current_time = 200.0; mock_time.return_value = current_time
-        gs.garlic_shot = {"active": True, "x": 10, "y": 10, "dx": 1, "dy": 0, "rotation_angle": 0, "image": mock_asset_manager.images['garlic']}
+        gs.garlic_shot = {"active": True, "x": 10, "y": 10, "dx": 1, "dy": 0, "rotation_angle": 0, "image": mock_asset_manager.images['garlic'], "rect": pygame.Rect(10, 10, 10, 10)}
         gs.garlic_shot_speed = GARLIC_SHOT_SPEED; gs.garlic_shot_duration = GARLIC_SHOT_DURATION
         gs.garlic_shot_travel = GARLIC_SHOT_MAX_TRAVEL - gs.garlic_shot_speed / 2
         gs.garlic_shot_start_time = current_time


### PR DESCRIPTION
Refactor(game_state): Improve imports and apply performance optimizations

This commit addresses code review feedback by refactoring `game_state.py` and `main.py`.

Changes:
- Replaced wildcard import in `game_state.py` with an explicit `import config` and prefixed all constants with `config.`.
- Added a missing `pygame` import to `game_state.py` and reordered all imports to follow PEP 8 guidelines.
- Implemented performance optimizations:
    - Pre-calculated the carrot spawn safe radius in `GameState.__init__` to avoid repeated calculations.
    - Modified the creation of the `garlic_shot` in `main.py` to include a `pygame.Rect` object, and updated `game_state.py` to reuse this rect for collision detection instead of creating a new one on every frame.
- Updated unit tests to reflect these changes.