### PR TITLE
Refactor game state imports

### DIFF
--- a/game_state.py
+++ b/game_state.py
@@ -39,6 +39,7 @@ class GameState:
         self.scroll = [0, 0]  # Camera scroll position / *Position de défilement de la caméra*
         self.scroll_trigger = config.SCROLL_TRIGGER  # Screen edge percentage to trigger scroll / *Pourcentage du bord de l'écran pour déclencher le défilement*
         self.world_size = config.WORLD_SIZE  # Total dimensions of the game world / *Dimensions totales du monde du jeu*
+        self.carrot_spawn_safe_radius_sq = (min(self.world_size) / config.CARROT_SPAWN_SAFE_RATIO)**2
         self.game_over = False  # True if the game has ended / *True si le jeu est terminé*
         self.started = False  # True if the game has started (past the initial screen) / *True si le jeu a commencé (après l'écran initial)*
         self.paused = False  # True if the game is currently paused / *True si le jeu est actuellement en pause*
@@ -208,7 +209,7 @@ class GameState:
 
             if not self.player or \
                ((x - player_center_x)**2 +
-                (y - player_center_y)**2 > (min(self.world_size)/config.CARROT_SPAWN_SAFE_RATIO)**2):
+                (y - player_center_y)**2 > self.carrot_spawn_safe_radius_sq):
                 self.carrots.append(Carrot(x, y, carrot_image_data, cli_mode=self.cli_mode))
                 break
 
@@ -286,12 +287,8 @@ class GameState:
             # Check for collision with vampire (only if garlic shot still exists and is active)
             # *Vérifier la collision avec le vampire (seulement si le tir d'ail existe encore et est actif)*
             if self.garlic_shot and self.garlic_shot["active"] and self.vampire.active:
-                # Ensure garlic_width and garlic_height are accessible or defined
-                # *S'assurer que garlic_width et garlic_height sont accessibles ou définis*
-                garlic_rect = pygame.Rect(self.garlic_shot["x"] - config.GARLIC_WIDTH / 2,
-                                          self.garlic_shot["y"] - config.GARLIC_HEIGHT / 2,
-                                          config.GARLIC_WIDTH, config.GARLIC_HEIGHT)
-                if garlic_rect.colliderect(self.vampire.rect):
+                self.garlic_shot["rect"].center = (self.garlic_shot["x"], self.garlic_shot["y"])
+                if self.garlic_shot["rect"].colliderect(self.vampire.rect):
                     self.vampire.death_effect_active = True
                     self.vampire.death_effect_start_time = current_time
                     self.vampire.active = False

--- a/game_state.py
+++ b/game_state.py
@@ -14,8 +14,7 @@ import pygame # Added for pygame.math.Vector2 / *Ajouté pour pygame.math.Vector
 import math   # Added for math.sqrt / *Ajouté pour math.sqrt*
 import logging # For logging debug/info messages / *Pour journaliser les messages de débogage/info*
 from game_entities import Carrot, Vampire, Player, Bullet, GarlicShot, Explosion, Collectible
-from config import *
-from config import IMAGE_ASSET_CONFIG
+import config
 
 class GameState:
     """
@@ -36,8 +35,8 @@ class GameState:
         """
         self.cli_mode = cli_mode
         self.scroll = [0, 0]  # Camera scroll position / *Position de défilement de la caméra*
-        self.scroll_trigger = SCROLL_TRIGGER  # Screen edge percentage to trigger scroll / *Pourcentage du bord de l'écran pour déclencher le défilement*
-        self.world_size = WORLD_SIZE  # Total dimensions of the game world / *Dimensions totales du monde du jeu*
+        self.scroll_trigger = config.SCROLL_TRIGGER  # Screen edge percentage to trigger scroll / *Pourcentage du bord de l'écran pour déclencher le défilement*
+        self.world_size = config.WORLD_SIZE  # Total dimensions of the game world / *Dimensions totales du monde du jeu*
         self.game_over = False  # True if the game has ended / *True si le jeu est terminé*
         self.started = False  # True if the game has started (past the initial screen) / *True si le jeu a commencé (après l'écran initial)*
         self.paused = False  # True if the game is currently paused / *True si le jeu est actuellement en pause*
@@ -50,8 +49,8 @@ class GameState:
         self.garlic_shot_travel = 0
 
         self.vampire = Vampire(
-            random.randint(0, WORLD_SIZE[0]), 
-            random.randint(0, WORLD_SIZE[1]),
+            random.randint(0, config.WORLD_SIZE[0]),
+            random.randint(0, config.WORLD_SIZE[1]),
             asset_manager.images['vampire'],
             cli_mode=self.cli_mode
         )
@@ -69,14 +68,14 @@ class GameState:
         # self.garlic_shot = None
         # self.garlic_shot_travel = 0
         # self.garlic_shot_start_time = 0
-        self.garlic_shot_speed = GARLIC_SHOT_SPEED
-        self.garlic_shot_duration = GARLIC_SHOT_DURATION
+        self.garlic_shot_speed = config.GARLIC_SHOT_SPEED
+        self.garlic_shot_duration = config.GARLIC_SHOT_DURATION
         
         self.vampire_killed_count = 0  # Track vampires killed / *Compteur de vampires tués*
         self.last_vampire_death_pos = (0, 0)  # Position tracking for item drops from vampire / *Suivi de la position pour les chutes d'objets du vampire*
 
         # Initialize carrots / *Initialiser les carottes*
-        for _ in range(CARROT_COUNT):
+        for _ in range(config.CARROT_COUNT):
             self.create_carrot(asset_manager)
 
     def reset(self):
@@ -121,7 +120,7 @@ class GameState:
                 if size_hint:
                     vampire_width, vampire_height = size_hint
                 else: # Fallback if no size info in CLI metadata
-                    vampire_width, vampire_height = IMAGE_ASSET_CONFIG['vampire']['size']
+                    vampire_width, vampire_height = config.IMAGE_ASSET_CONFIG['vampire']['size']
 
             self.vampire.active = False
             self.vampire.death_effect_active = False
@@ -138,7 +137,7 @@ class GameState:
             
         # Recreate carrots with fresh instances / *Recréer les carottes avec de nouvelles instances*
         self.carrots = []
-        for _ in range(CARROT_COUNT):
+        for _ in range(config.CARROT_COUNT):
             self.create_carrot(self.asset_manager)
 
     def add_bullet(self, start_x, start_y, target_x, target_y, image):
@@ -188,7 +187,7 @@ class GameState:
                 if size_hint:
                     carrot_width, carrot_height = size_hint
                 else: # Fallback if no size info in CLI metadata
-                    carrot_width, carrot_height = IMAGE_ASSET_CONFIG['carrot']['size'] # Default size from config
+                    carrot_width, carrot_height = config.IMAGE_ASSET_CONFIG['carrot']['size'] # Default size from config
             elif hasattr(carrot_image_data, 'get_width'): # GUI mode, actual surface
                 carrot_width = carrot_image_data.get_width()
                 carrot_height = carrot_image_data.get_height()
@@ -207,7 +206,7 @@ class GameState:
 
             if not self.player or \
                ((x - player_center_x)**2 +
-                (y - player_center_y)**2 > (min(self.world_size)/CARROT_SPAWN_SAFE_RATIO)**2):
+                (y - player_center_y)**2 > (min(self.world_size)/config.CARROT_SPAWN_SAFE_RATIO)**2):
                 self.carrots.append(Carrot(x, y, carrot_image_data, cli_mode=self.cli_mode))
                 break
 
@@ -260,18 +259,18 @@ class GameState:
 
         # Respawn carrots after delay / *Faire réapparaître les carottes après un délai*
         for carrot in self.carrots:
-            if not carrot.active and (current_time - carrot.respawn_timer > CARROT_RESPAWN_DELAY):
+            if not carrot.active and (current_time - carrot.respawn_timer > config.CARROT_RESPAWN_DELAY):
                 carrot.respawn_timer = 0  # Reset timer / *Réinitialiser le minuteur*
                 carrot.respawn(self.world_size, self.player.rect) # Call carrot's own respawn logic
                                                                   # *Appeler la logique de réapparition propre à la carotte*
 
         # Garlic shot logic / *Logique du tir d'ail*
         if self.garlic_shot and self.garlic_shot["active"]:
-            if self.garlic_shot_travel < GARLIC_SHOT_MAX_TRAVEL and \
+            if self.garlic_shot_travel < config.GARLIC_SHOT_MAX_TRAVEL and \
                (current_time - self.garlic_shot_start_time <= self.garlic_shot_duration): # Check duration as well
                                                                                            # *Vérifier également la durée*
                 # Update rotation angle each frame / *Mettre à jour l'angle de rotation à chaque frame*
-                self.garlic_shot["rotation_angle"] = (self.garlic_shot["rotation_angle"] + GARLIC_ROTATION_SPEED) % 360
+                self.garlic_shot["rotation_angle"] = (self.garlic_shot["rotation_angle"] + config.GARLIC_ROTATION_SPEED) % 360
                 # Move in the pre-calculated direction / *Se déplacer dans la direction pré-calculée*
                 self.garlic_shot["x"] += self.garlic_shot["dx"] * self.garlic_shot_speed
                 self.garlic_shot["y"] += self.garlic_shot["dy"] * self.garlic_shot_speed
@@ -287,9 +286,9 @@ class GameState:
             if self.garlic_shot and self.garlic_shot["active"] and self.vampire.active:
                 # Ensure garlic_width and garlic_height are accessible or defined
                 # *S'assurer que garlic_width et garlic_height sont accessibles ou définis*
-                garlic_rect = pygame.Rect(self.garlic_shot["x"] - GARLIC_WIDTH / 2,
-                                          self.garlic_shot["y"] - GARLIC_HEIGHT / 2,
-                                          GARLIC_WIDTH, GARLIC_HEIGHT)
+                garlic_rect = pygame.Rect(self.garlic_shot["x"] - config.GARLIC_WIDTH / 2,
+                                          self.garlic_shot["y"] - config.GARLIC_HEIGHT / 2,
+                                          config.GARLIC_WIDTH, config.GARLIC_HEIGHT)
                 if garlic_rect.colliderect(self.vampire.rect):
                     self.vampire.death_effect_active = True
                     self.vampire.death_effect_start_time = current_time
@@ -312,7 +311,7 @@ class GameState:
         # *Gérer les animations de mort de vampire terminées et la chute d'objets*
         if self.vampire.death_effect_active and \
            not self.vampire.active and \
-           (current_time - self.vampire.death_effect_start_time >= VAMPIRE_DEATH_DURATION):
+           (current_time - self.vampire.death_effect_start_time >= config.VAMPIRE_DEATH_DURATION):
 
             self.vampire.death_effect_active = False # Clear flag / *Effacer l'indicateur*
 
@@ -324,7 +323,7 @@ class GameState:
                     self.last_vampire_death_pos[1],
                     self.asset_manager.images['carrot_juice'],
                     'carrot_juice', # item_type
-                    ITEM_SCALE,
+                    config.ITEM_SCALE,
                     cli_mode=self.cli_mode
                 )
             )
@@ -347,7 +346,7 @@ class GameState:
             if explosion.update(current_time): # update returns True when explosion is finished
                                                # *update retourne True quand l'explosion est terminée*
                 # Create collectible item (HP or Garlic) / *Créer un objet collectable (PV ou Ail)*
-                is_garlic = random.random() < ITEM_DROP_GARLIC_CHANCE
+                is_garlic = random.random() < config.ITEM_DROP_GARLIC_CHANCE
                 item_image_key = 'garlic' if is_garlic else 'hp'
                 item_type = 'garlic' if is_garlic else 'hp'
 
@@ -357,7 +356,7 @@ class GameState:
                         explosion.rect.centery,
                         self.asset_manager.images[item_image_key],
                         item_type,
-                        ITEM_SCALE,
+                        config.ITEM_SCALE,
                         cli_mode=self.cli_mode
                     )
                 )
@@ -369,20 +368,20 @@ class GameState:
             if item.active and self.player.rect.colliderect(item.rect):
                 logging.debug(f"Player collecting item: {item.item_type}. Player HP: {self.player.health}, Garlic: {self.player.garlic_count} / Joueur ramassant l'objet : {item.item_type}. PV Joueur : {self.player.health}, Ail : {self.player.garlic_count}")
                 collected = False
-                if item.item_type == 'hp' and self.player.health < MAX_HEALTH:
+                if item.item_type == 'hp' and self.player.health < config.MAX_HEALTH:
                     self.player.health += 1
                     self.player.health_changed = True # For UI update / *Pour mise à jour UI*
                     if not self.cli_mode: self.asset_manager.sounds['get_hp'].play()
                     collected = True
                     logging.info(f"Player collected HP. Current HP: {self.player.health} / Joueur a ramassé PV. PV actuels : {self.player.health}")
-                elif item.item_type == 'garlic' and self.player.garlic_count < MAX_GARLIC:
+                elif item.item_type == 'garlic' and self.player.garlic_count < config.MAX_GARLIC:
                     self.player.garlic_count += 1
                     self.player.garlic_changed = True # For UI update / *Pour mise à jour UI*
                     if not self.cli_mode: self.asset_manager.sounds['get_garlic'].play()
                     collected = True
                     logging.info(f"Player collected Garlic. Current Garlic: {self.player.garlic_count} / Joueur a ramassé Ail. Ail actuel : {self.player.garlic_count}")
                 elif item.item_type == 'carrot_juice':
-                    self.player.carrot_juice_count = min(self.player.carrot_juice_count + 1, MAX_CARROT_JUICE)
+                    self.player.carrot_juice_count = min(self.player.carrot_juice_count + 1, config.MAX_CARROT_JUICE)
                     self.player.juice_changed = True # For UI update / *Pour mise à jour UI*
                     if not self.cli_mode: self.asset_manager.sounds['get_hp'].play()  # Reuse existing pickup sound / *Réutiliser son de ramassage existant*
                     collected = True

--- a/game_state.py
+++ b/game_state.py
@@ -9,12 +9,14 @@
 # *(joueur, ennemis, projectiles, objets), gère les conditions de jeu (par ex. game over,
 # *en pause), s'occupe des interactions entre entités, des mises à jour et réinitialise le jeu.*
 
+import logging
+import math
 import random
-import pygame # Added for pygame.math.Vector2 / *Ajouté pour pygame.math.Vector2*
-import math   # Added for math.sqrt / *Ajouté pour math.sqrt*
-import logging # For logging debug/info messages / *Pour journaliser les messages de débogage/info*
-from game_entities import Carrot, Vampire, Player, Bullet, GarlicShot, Explosion, Collectible
+
+import pygame
+
 import config
+from game_entities import Carrot, Vampire, Player, Bullet, GarlicShot, Explosion, Collectible
 
 class GameState:
     """

--- a/main.py
+++ b/main.py
@@ -457,11 +457,14 @@ def run_gui_mode():
                     dx_norm, dy_norm = (dx/dist, dy/dist) if dist > 0 else (0,1)
                     angle = math.degrees(math.atan2(-dy_norm, dx_norm))
 
+                    rect = pygame.Rect(0, 0, config.GARLIC_WIDTH, config.GARLIC_HEIGHT)
+                    rect.center = (start_x, start_y)
                     game_state.garlic_shot = {
                         "x": start_x, "y": start_y,
                         "dx": dx_norm, "dy": dy_norm,
                         "angle": angle, "active": True,
-                        "rotation_angle": angle
+                        "rotation_angle": angle,
+                        "rect": rect
                     }
                     game_state.garlic_shot_travel = 0
                     logging.debug(f"Garlic shot initiated towards ({world_mouse_x},{world_mouse_y}) with angle {angle:.2f} / Tir d'ail initié vers ({world_mouse_x},{world_mouse_y}) avec un angle de {angle:.2f}")

--- a/tests/test_game_state.py
+++ b/tests/test_game_state.py
@@ -4,7 +4,12 @@ import random
 
 from game_state import GameState
 from game_entities import Player, Vampire, Carrot, Bullet, GarlicShot, Explosion, Collectible
-from config import *
+from config import (
+    SCROLL_TRIGGER, WORLD_SIZE, CARROT_COUNT, START_HEALTH,
+    GARLIC_SHOT_SPEED, GARLIC_SHOT_DURATION, GARLIC_WIDTH, GARLIC_HEIGHT,
+    CARROT_RESPAWN_DELAY, BULLET_SPEED, VAMPIRE_DEATH_DURATION,
+    ITEM_DROP_GARLIC_CHANCE, ITEM_SCALE, MAX_HEALTH, GARLIC_SHOT_MAX_TRAVEL
+)
 from .test_utils import mock_asset_manager, mock_pygame_init_and_display, real_surface_factory, initialized_pygame
 
 import pygame
@@ -230,7 +235,7 @@ class TestGameStateUpdate:
         vampire.rect = pygame.Rect(200, 200, 40, 40); vampire.active = True
         gs.garlic_shot = {
             "active": True, "x": 200, "y": 200, "dx": 1, "dy": 0,
-            "image": MagicMock(), "rotation_angle": 0, "rect": pygame.Rect(195, 195, 10, 10)
+            "image": MagicMock(), "rotation_angle": 0, "rect": pygame.Rect(0, 0, GARLIC_WIDTH, GARLIC_HEIGHT)
         }
         gs.garlic_shot["rect"].center = (gs.garlic_shot["x"], gs.garlic_shot["y"])
         gs.garlic_shot_start_time = current_time - 0.1; gs.garlic_shot_travel = 0
@@ -355,7 +360,8 @@ class TestGameStateUpdate:
     @patch('time.time')
     def test_update_garlic_shot_expiration_by_travel(self, mock_time, game_state_instance, mock_asset_manager):
         gs = game_state_instance; current_time = 200.0; mock_time.return_value = current_time
-        gs.garlic_shot = {"active": True, "x": 10, "y": 10, "dx": 1, "dy": 0, "rotation_angle": 0, "image": mock_asset_manager.images['garlic'], "rect": pygame.Rect(10, 10, 10, 10)}
+        gs.garlic_shot = {"active": True, "x": 10, "y": 10, "dx": 1, "dy": 0, "rotation_angle": 0, "image": mock_asset_manager.images['garlic'], "rect": pygame.Rect(0, 0, GARLIC_WIDTH, GARLIC_HEIGHT)}
+        gs.garlic_shot["rect"].center = (gs.garlic_shot["x"], gs.garlic_shot["y"])
         gs.garlic_shot_speed = GARLIC_SHOT_SPEED; gs.garlic_shot_duration = GARLIC_SHOT_DURATION
         gs.garlic_shot_travel = GARLIC_SHOT_MAX_TRAVEL - gs.garlic_shot_speed / 2
         gs.garlic_shot_start_time = current_time

--- a/tests/test_game_state.py
+++ b/tests/test_game_state.py
@@ -223,31 +223,23 @@ class TestGameStateUpdate:
         assert gs.bullets[0].rect.centerx == initial_center_x_on_screen + BULLET_SPEED
 
     @patch('time.time')
-    @patch('game_state.pygame.Rect')
-    def test_update_garlic_shot_vampire_collision(self, mock_pygame_rect_class, mock_time, game_state_instance, mock_asset_manager):
+    def test_update_garlic_shot_vampire_collision(self, mock_time, game_state_instance, mock_asset_manager):
         gs = game_state_instance; vampire = gs.vampire; current_time = 100.0
         mock_time.return_value = current_time
-        mock_pygame_rect_class.return_value.colliderect.return_value = True
 
         vampire.rect = pygame.Rect(200, 200, 40, 40); vampire.active = True
         gs.garlic_shot = {
             "active": True, "x": 200, "y": 200, "dx": 1, "dy": 0,
-            "image": MagicMock(), "rotation_angle": 0
+            "image": MagicMock(), "rotation_angle": 0, "rect": pygame.Rect(195, 195, 10, 10)
         }
+        gs.garlic_shot["rect"].center = (gs.garlic_shot["x"], gs.garlic_shot["y"])
         gs.garlic_shot_start_time = current_time - 0.1; gs.garlic_shot_travel = 0
         gs.garlic_shot_speed = GARLIC_SHOT_SPEED; gs.garlic_shot_duration = GARLIC_SHOT_DURATION
 
-        expected_center_x_after_move = gs.garlic_shot["x"] + gs.garlic_shot["dx"] * gs.garlic_shot_speed
-        expected_center_y_after_move = gs.garlic_shot["y"] + gs.garlic_shot["dy"] * gs.garlic_shot_speed
-
-        expected_topleft_x = expected_center_x_after_move - GARLIC_WIDTH / 2
-        expected_topleft_y = expected_center_y_after_move - GARLIC_HEIGHT / 2
-
         gs.update(current_time)
 
-        mock_pygame_rect_class.assert_called_with(pytest.approx(expected_topleft_x), pytest.approx(expected_topleft_y), GARLIC_WIDTH, GARLIC_HEIGHT)
-        mock_pygame_rect_class.return_value.colliderect.assert_called_once_with(vampire.rect)
         assert vampire.death_effect_active
+        assert gs.garlic_shot is None
 
     @patch('time.time')
     def test_update_player_vampire_collision(self, mock_time, game_state_instance):
@@ -363,7 +355,7 @@ class TestGameStateUpdate:
     @patch('time.time')
     def test_update_garlic_shot_expiration_by_travel(self, mock_time, game_state_instance, mock_asset_manager):
         gs = game_state_instance; current_time = 200.0; mock_time.return_value = current_time
-        gs.garlic_shot = {"active": True, "x": 10, "y": 10, "dx": 1, "dy": 0, "rotation_angle": 0, "image": mock_asset_manager.images['garlic']}
+        gs.garlic_shot = {"active": True, "x": 10, "y": 10, "dx": 1, "dy": 0, "rotation_angle": 0, "image": mock_asset_manager.images['garlic'], "rect": pygame.Rect(10, 10, 10, 10)}
         gs.garlic_shot_speed = GARLIC_SHOT_SPEED; gs.garlic_shot_duration = GARLIC_SHOT_DURATION
         gs.garlic_shot_travel = GARLIC_SHOT_MAX_TRAVEL - gs.garlic_shot_speed / 2
         gs.garlic_shot_start_time = current_time


### PR DESCRIPTION
Refactor: Improve imports, performance, and test consistency

This commit addresses multiple rounds of code review feedback, resulting in a cleaner, more performant, and more maintainable codebase.

Changes:
- Replaced wildcard imports in `game_state.py` and `tests/test_game_state.py` with explicit, specific imports to improve clarity and prevent namespace pollution.
- Implemented performance optimizations:
    - Pre-calculated the carrot spawn safe radius in `GameState.__init__` to avoid repeated calculations in a loop.
    - Modified the creation of the `garlic_shot` in `main.py` to include a `pygame.Rect` object, and updated `game_state.py` to reuse this rect for collision detection instead of creating a new one on every frame.
- Updated unit tests to reflect these changes and to use configuration constants for test data, improving consistency with the application code.