### PR TITLE
Fix: Add rect key to garlic_shot dictionary

### DIFF
--- a/main.py
+++ b/main.py
@@ -461,7 +461,8 @@ def run_gui_mode():
                         "x": start_x, "y": start_y,
                         "dx": dx_norm, "dy": dy_norm,
                         "angle": angle, "active": True,
-                        "rotation_angle": angle
+                        "rotation_angle": angle,
+                        "rect": garlic_image.get_rect(center=(start_x, start_y))
                     }
                     game_state.garlic_shot_travel = 0
                     logging.debug(f"Garlic shot initiated towards ({world_mouse_x},{world_mouse_y}) with angle {angle:.2f} / Tir d'ail initié vers ({world_mouse_x},{world_mouse_y}) avec un angle de {angle:.2f}")


### PR DESCRIPTION
This commit fixes a crash that occurred when firing a garlic shot. The `rect` key was missing from the `garlic_shot` dictionary, which caused a `KeyError` during collision detection.

The fix adds the `rect` key to the `garlic_shot` dictionary upon its creation in `main.py`, ensuring it's available for collision detection in `game_state.py`.